### PR TITLE
Set default values to prevent undef warnings.

### DIFF
--- a/lib/Plack/Middleware/Debug/LWP.pm
+++ b/lib/Plack/Middleware/Debug/LWP.pm
@@ -56,7 +56,7 @@ sub run {
 		my $profile = LWPx::Profile::stop_profiling();
 		
 		my @lines;
-		my ($time, $requests);
+		my ($time, $requests) = (0, 0);
 		
 		for my $req (sort {
 			$profile->{$a}->{time_of_first_sample} <=> $profile->{$b}->{time_of_first_sample}


### PR DESCRIPTION
This prevents "Use of uninitialized value" warnings for both $requests and $time for any request that doesn't make any requests.

Sorry, have only noticed this now I've included it in our project.